### PR TITLE
Gradle run task error with Spring boot 1.1.4.RELEASE

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -42,7 +42,7 @@ SpringGenerator.prototype.askFor = function askFor() {
             type: 'string',
             name: 'bootVersion',
             message: '(1/6) What version of Spring Boot would you like to use?',
-            default: '0.5.0.M5'
+            default: '1.1.4.RELEASE'
         },
         {
             type: 'string',

--- a/app/templates/build.gradle
+++ b/app/templates/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'<%}%>
 }
 
-task run(type:Exec){
+task run(type: Exec, overwrite: true){
     commandLine "java -jar build/libs/<%=baseName%>-0.1.0.jar".split(' ')
 }
 


### PR DESCRIPTION
After changing the default spring boot version to 1.1.4.RELEASE, running ```gradle run``` (or any Gradle command) right after scaffolding out the the app throws the following error:

![screen shot 2014-07-10 at 4 10 27 pm](https://cloud.githubusercontent.com/assets/91259/3546769/b7ca4b88-0889-11e4-9059-1faf0172b8e7.png)
 
Added ```overwrite:true``` to the run task seems to fix.

Env:
Mac OSX 10.9.4
Gradle 2.0
 